### PR TITLE
Fix some bug and add a little operation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,6 +30,7 @@ jobs:
               env:
                   GH_PUSH_TOKEN: ${{secrets.GH_PUSH_TOKEN}}
               run: |
+                  npm install
                   git config --global user.name 'ElderJames'
                   git config --global user.email 'shunjiey@hotmail.com'
                   dotnet publish -c Release -o tmp
@@ -40,7 +41,7 @@ jobs:
                   git init
                   git checkout -b gh-pages
                   git add -A
-                  git commit -m "Create build $GITHUB_RUN_ID"
+                  git commit -m "docs: Create build $GITHUB_RUN_ID"
                   git push -f https://ElderJames:$GH_PUSH_TOKEN@github.com/ElderJames/ant-design-blazor.git gh-pages
 
             - name: Package Nightly Nuget

--- a/components/AntBlazor.xml
+++ b/components/AntBlazor.xml
@@ -103,6 +103,18 @@
         <member name="M:AntBlazor.AntInputComponentBase`1.SetParametersAsync(Microsoft.AspNetCore.Components.ParameterView)">
             <inheritdoc />
         </member>
+        <member name="M:AntBlazor.StyleHelper.ToCssPixel(System.String)">
+            <summary>
+            fix the user set 100% or xxxVH etc..
+            </summary>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
+        <member name="P:AntBlazor.AntLayoutSiderBase.longBodyMode">
+            <summary>
+            use to fix the user has long content, but they don't want to scroll all body.
+            </summary>
+        </member>
         <member name="P:AntBlazor.AntLayoutSiderBase.adBreakpoint">
             <summary>
             "xs" | "sm" | "md" | "lg" | "xl" | "xxl"
@@ -151,6 +163,11 @@
         <member name="P:AntBlazor.AntDivider.orientation">
             <summary>
             'left' | 'right' | 'center'
+            </summary>
+        </member>
+        <member name="P:AntBlazor.AntLayoutContent.longContentMode">
+            <summary>
+            use to fix the user has long content, but they don't want to scroll all body.
             </summary>
         </member>
         <member name="P:AntBlazor.AntTag.mode">

--- a/components/core/Helpers/StyleHelper.cs
+++ b/components/core/Helpers/StyleHelper.cs
@@ -2,14 +2,7 @@
 {
     public class StyleHelper
     {
-        public static string ToCssPixel(string value)
-        {
-            if (value.EndsWith("px"))
-            {
-                return value;
-            }
-
-            return $"{value}px";
-        }
+        //fix the user set 100% or xxxVH etc.. 
+        public static string ToCssPixel(string value)=> int.TryParse(value, out var _) ? $"{value}px" : value;
     }
 }

--- a/components/layout/AntLayoutContent.razor
+++ b/components/layout/AntLayoutContent.razor
@@ -1,12 +1,21 @@
 ﻿@namespace AntBlazor
 @inherits AntDomComponentBase
 
-<nz-content class="@ClassMapper.Class" @ref="Ref" style="display: block;@Style" @attributes="Attributes" Id="@Id">
+<nz-content class="@ClassMapper.Class" @ref="Ref" style="@_customStyle; display: block;@Style" @attributes="Attributes" Id="@Id">
     @ChildContent
 </nz-content>
 @code {
     [Parameter]
     public RenderFragment ChildContent { get; set; }
+
+    /// <summary>
+    /// use to fix the user has long content, but they don't want to scroll all body.
+    /// </summary>
+    [Parameter]
+    public bool longContentMode { get; set; } = false;
+
+    private string _customStyle=>
+        @$"{(longContentMode?"min-height:auto;":"")}";
 
     public AntLayoutContent()
     {

--- a/components/layout/AntLayoutSiderBase.cs
+++ b/components/layout/AntLayoutSiderBase.cs
@@ -7,11 +7,19 @@ namespace AntBlazor
 {
     public class AntLayoutSiderBase : AntDomComponentBase
     {
+        private string _currentWidth, _customWidth = "256";
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 
         [Parameter]
-        public string adWidth { get; set; }
+        public string adWidth { get => _currentWidth; set { _currentWidth = _customWidth = value; } }
+
+        /// <summary>
+        /// use to fix the user has long content, but they don't want to scroll all body.
+        /// </summary>
+        [Parameter]
+        public bool longBodyMode { get; set; } = false;
+
 
         [Parameter]
         public string adTheme { get; set; } = "dark";
@@ -50,13 +58,14 @@ namespace AntBlazor
 
         protected string widthSetting => this.adCollapsed ? $"{this.adCollapsedWidth}px" : StyleHelper.ToCssPixel(adWidth);
 
-        private string flexSetting => $"0 0 ${widthSetting}";
+        private string flexSetting => $"0 0 {widthSetting}";
 
         protected string style =>
-                    $@"flex:{flexSetting}
+                    $@"flex:{flexSetting};
                     max-width:{widthSetting};
                     min-width:{widthSetting};
-                    width:{widthSetting};";
+                    width:{widthSetting};
+                    {(longBodyMode ? ";overflow:auto;height:100vh !important;position:fixed;left:0;" : "")}";
 
         protected bool below { get; set; }
 
@@ -106,6 +115,14 @@ namespace AntBlazor
             var matchBelow = await JsInvokeAsync<bool>("antMatchMedia", $"(max-width: {dimensionMap[adBreakpoint]})");
             this.below = matchBelow;
             this.adCollapsed = matchBelow;
+            if (matchBelow)
+            {
+                this._currentWidth = "100%";
+            }
+            else
+            {
+                this._currentWidth = this._customWidth;
+            }
             await this.onCollapsedChange.InvokeAsync(matchBelow);
         }
     }

--- a/site/AntBlazor.Docs.ServerApp/Properties/launchSettings.json
+++ b/site/AntBlazor.Docs.ServerApp/Properties/launchSettings.json
@@ -1,24 +1,13 @@
 {
   "iisSettings": {
     "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:57296",
-      "sslPort": 44317
-    }
+    "anonymousAuthentication": true 
   },
-  "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
+  "profiles": { 
     "AntBlazor.Docs.ServerApp": {
       "commandName": "Project",
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/site/AntBlazor.Docs/Shared/MainLayout.razor
+++ b/site/AntBlazor.Docs/Shared/MainLayout.razor
@@ -3,9 +3,9 @@
 <AntLayout Class="app-layout" HasSider="true">
     <AntLayoutSider class="menu-sidebar"
                     adCollapsible
-                    adWidth="256px"
                     adBreakpoint="md"
                     adCollapsed="isCollapsed"
+                    longBodyMode=true
                     onCollapsedChange="(collapsed)=>isCollapsed = collapsed">
         <div class="sidebar-logo">
             <a href="https://github.com/ElderJames/ant-design-blazor" target="_blank">
@@ -13,7 +13,7 @@
                 <h1>Ant Design for Blazor</h1>
             </a>
         </div>
-        <AntMenu nzTheme="dark" nzMode="NzDirectionVHIType.inline" nzInlineCollapsed="isCollapsed">
+        <AntMenu nzTheme="dark" nzMode="NzDirectionVHIType.inline" Style="margin-bottom:40px;" nzInlineCollapsed="isCollapsed">
             <AntSubMenu nzOpen nzTitle="Dashboard" nzIcon="dashboard">
                 <AntMenuItem nzMatchRouter>
                     <AntNavLink href="" Match="NavLinkMatch.All">
@@ -70,7 +70,7 @@
             </AntSubMenu>
         </AntMenu>
     </AntLayoutSider>
-    <AntLayout>
+    <AntLayout class="main-content" Style="@(isCollapsed?"margin-left:80px":"margin-left:256px")">
         <AntLayoutHeader>
             <div class="app-header">
                 <span class="header-trigger" @onclick="()=>isCollapsed = !isCollapsed">
@@ -78,17 +78,19 @@
                 </span>
             </div>
         </AntLayoutHeader>
-        <AntLayoutContent>
+        <AntLayoutContent longContentMode=true>
             <div class="inner-content">
                 @Body
             </div>
         </AntLayoutContent>
+        <AntLayoutFooter Style="text-align:center;">
+            Ant Design for Blazor @@2020 Create by XXX
+        </AntLayoutFooter>
     </AntLayout>
 </AntLayout>
 
 @code
 {
 
-    bool isCollapsed = false;
-
+    bool isCollapsed = false; 
 }


### PR DESCRIPTION
feat：
1.add the "longBodyMode" parameter to AntLayoutSider.
2.add the "longContentMode" parameter to AntLayoutContent
3.add the self-adaption mode to side bar.
fix：
1.fix doc project page layout. 
2.set the default width value, cause if use forgot set this value, there throw the nullreference exception.
3.fix the user set 100% or xxxVH etc. the old style will add the px end of string. 
style： 
1.fix the menu margin, you will found that you lost one menu item which lastest in list.
2.add the footer to main layout
refactor：
1.Hide the adWidth
