### PR TITLE
Add EditorConfig for naming conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.cs]
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none
+
+# IDE1006: Naming Styles
+dotnet_diagnostic.IDE1006.severity = error

--- a/AntBlazor.sln
+++ b/AntBlazor.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 16.0.29519.181
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0CB79B3D-E483-4051-8026-6A80FCA0C6A6}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		.github\workflows\gh-pages.yml = .github\workflows\gh-pages.yml
 		README.md = README.md
 		.github\workflows\style-sync.yml = .github\workflows\style-sync.yml

--- a/components/AntBlazor.csproj
+++ b/components/AntBlazor.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>


### PR DESCRIPTION
- Invalid Property Naming convention will now throw an error instead of a warning, which will act like a Linter. However the build will still succeed on the GitHub workflow and locally(with errors) due to [this issue that has to be resolved by Microsoft](dotnet/roslyn#33558)
- Disabled the XML comments, it's handy but not always needed at this point.

![image](https://user-images.githubusercontent.com/10981553/77260989-7d7fc180-6c8b-11ea-81f5-e1cd6e8e2d00.png)
